### PR TITLE
ProcessID => CensusID

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -10,30 +10,30 @@ processHttp.Listen(1500, "http")
 #### add claims
 
 ```
-curl -d '{"processID":"GoT_Favorite","claimData":"Jon Snow"}' http://localhost:1500/addClaim
+curl -d '{"censusID":"GoT_Favorite","claimData":"Jon Snow"}' http://localhost:1500/addClaim
 {"error":false,"response":""}
 ```
 
 ```
-curl -d '{"processID":"GoT_Favorite","claimData":"Tyrion"}' http://localhost:1500/addClaim
+curl -d '{"censusID":"GoT_Favorite","claimData":"Tyrion"}' http://localhost:1500/addClaim
 {"error":false,"response":""}
 ```
 
 #### generate proof
 
 ```
-curl -d '{"processID":"GoT_Favorite","claimData":"Jon Snow"}' http://localhost:1500/genProof
+curl -d '{"censusID":"GoT_Favorite","claimData":"Jon Snow"}' http://localhost:1500/genProof
 {"error":false,"response":"0x000000000000000000000000000000000000000000000000000000000000000352f3ca2aaf635ec2ae4452f6a65be7bca72678287a8bb08ad4babfcccd76c2fef1aac7675261bf6d12c746fb7907beea6d1f1635af93ba931eec0c6a747ecc37"}
 ```
 
 #### check proof
 
 ```
-curl -d '{"processID":"GoT_Favorite","claimData":"Jon Snow", "proofData": "0x0000000000000000000000000000000000000000000000000000000000000000000123"}' http://localhost:1500/checkProof
+curl -d '{"censusID":"GoT_Favorite","claimData":"Jon Snow", "proofData": "0x0000000000000000000000000000000000000000000000000000000000000000000123"}' http://localhost:1500/checkProof
 {"error":false,"response":"invalid"}
 ```
 
 ```
-curl -d '{"processID":"GoT_Favorite","claimData":"Jon Snow", "proofData": "0x000000000000000000000000000000000000000000000000000000000000000352f3ca2aaf635ec2ae4452f6a65be7bca72678287a8bb08ad4babfcccd76c2fef1aac7675261bf6d12c746fb7907beea6d1f1635af93ba931eec0c6a747ecc37"}' http://localhost:1500/checkProof
+curl -d '{"censusID":"GoT_Favorite","claimData":"Jon Snow", "proofData": "0x000000000000000000000000000000000000000000000000000000000000000352f3ca2aaf635ec2ae4452f6a65be7bca72678287a8bb08ad4babfcccd76c2fef1aac7675261bf6d12c746fb7907beea6d1f1635af93ba931eec0c6a747ecc37"}' http://localhost:1500/checkProof
 {"error":false,"response":"valid"}
 ```

--- a/service/processHttp.go
+++ b/service/processHttp.go
@@ -12,7 +12,7 @@ import (
 var T tree.Tree
 
 type Claim struct {
-	ProcessID string `json:"processID"`
+	CensusID string `json:"censusID"`
 	ClaimData string `json:"claimData"`
 	ProofData string `json:"proofData"`
 }
@@ -51,15 +51,15 @@ func claimHandler(w http.ResponseWriter, req *http.Request, op string) {
 	}
 
 	// Process data
-	log.Printf("Received: %s,%s,%s ", c.ProcessID, c.ClaimData, c.ProofData)
+	log.Printf("Received: %s,%s,%s ", c.CensusID, c.ClaimData, c.ProofData)
 	resp.Error = false
 	resp.Response = ""
 
-	if len(c.ProcessID) > 0 {
-		T.Namespace = c.ProcessID
+	if len(c.CensusID) > 0 {
+		T.Namespace = c.CensusID
 	} else {
 		resp.Error = true
-		resp.Response = "processID is not valid"
+		resp.Response = "CensusID is not valid"
 		reply(&resp, w)
 		return
 	}


### PR DESCRIPTION
Changed variable/parameter naming because 2 reasons:

- Building a census before creating a Process
- Multiple processes could potentially share the same census.